### PR TITLE
Fix incorrect orientation on sway/iio-sway restart

### DIFF
--- a/main.c
+++ b/main.c
@@ -35,9 +35,26 @@ DBusConnection* dbus_connect() {
     return NULL;
 }
 
-enum Orientation parse_orientation(DBusMessage* msg) {
+enum Orientation property_to_enum(const char* orientation) {
+    if (!strcmp(orientation, "normal")) {
+        return Normal;
+    }
+    if (!strcmp(orientation, "bottom-up")) {
+        return BottomUp;
+    }
+    if (!strcmp(orientation, "left-up")) {
+        return LeftUp;
+    }
+    if (!strcmp(orientation, "right-up")) {
+        return RightUp;
+    }
+
+    return Undefined;
+}
+
+enum Orientation parse_orientation_signal(DBusMessage* msg) {
     DBusMessageIter args, iter_array, iter_dict, iter_v;
-    char *iface, *property, *orientation;
+    const char *iface, *property, *orientation;
     if (dbus_message_iter_init(msg, &args)) {
         dbus_message_iter_get_basic(&args, &iface);
         if (!strcmp("net.hadess.SensorProxy", iface)) {
@@ -49,20 +66,7 @@ enum Orientation parse_orientation(DBusMessage* msg) {
                 dbus_message_iter_next(&iter_dict);
                 dbus_message_iter_recurse(&iter_dict, &iter_v);
                 dbus_message_iter_get_basic(&iter_v, &orientation);
-
-                if (!strcmp(orientation, "normal")) {
-                    return Normal;
-                }
-                if (!strcmp(orientation, "bottom-up")) {
-                    return BottomUp;
-                }
-                if (!strcmp(orientation, "left-up")) {
-                    return LeftUp;
-                }
-
-                if (!strcmp(orientation, "right-up")) {
-                    return RightUp;
-                }
+    		return property_to_enum(orientation);
             }
         }
     }
@@ -101,16 +105,64 @@ void handle_orientation(enum Orientation orientation) {
     }
 }
 
-int main(int argc, char* argv[]) {
-    DBusConnection* connection = dbus_connect();
-    if (connection == NULL) {
-        printf("error: cannot open dbus connection\n");
-        return 1;
-    }
-    if (argc > 1) {
-        output = argv[1];
+DBusMessage* request_orientation(DBusConnection* conn) {
+
+    // create request calling Get method
+    DBusMessage* req = dbus_message_new_method_call(
+        "net.hadess.SensorProxy", // destination
+        "/net/hadess/SensorProxy", // path
+        "org.freedesktop.DBus.Properties", // iface
+        "Get" // method
+    );
+
+    // append arguments of Get method to request
+    const char* interface_name = "net.hadess.SensorProxy";
+    const char* property_name = "AccelerometerOrientation";
+    dbus_message_append_args(req,
+        DBUS_TYPE_STRING, &interface_name,
+        DBUS_TYPE_STRING, &property_name,
+        DBUS_TYPE_INVALID
+    );
+
+    // send request and get reply
+    DBusMessage* reply = dbus_connection_send_with_reply_and_block(
+        conn,
+        req,
+        DBUS_TIMEOUT_INFINITE,
+        &error
+    );
+
+    // check reply
+    if (dbus_error_is_set(&error)) {
+        printf("Error receiving orientation request: %s: %s\n",
+	       error.name, error.message);
     }
 
+    // clean up and return
+    dbus_message_unref(req);
+    return reply;
+}
+
+enum Orientation parse_orientation_reply(DBusMessage* reply) {
+    DBusMessageIter iter, sub_iter;
+    const char* orientation;
+    dbus_message_iter_init(reply, &iter);
+    dbus_message_iter_recurse(&iter, &sub_iter); // DBUS_TYPE_VARIANT
+    dbus_message_iter_get_basic(&sub_iter, &orientation); // DBUS_TYPE_STRING
+    return property_to_enum(orientation);
+}
+
+void init_orientation(DBusConnection* conn) {
+// this function proactively requests current orientation, even if not changed
+    DBusMessage* reply = request_orientation(conn);
+    if (reply != NULL) {
+        handle_orientation(parse_orientation_reply(reply));
+        dbus_message_unref(reply);
+    }
+}
+
+void listen_orientation(DBusConnection* connection) {
+// this function passively listens for changes to orientation
     DBusMessage* msg;
     dbus_bus_add_match(connection,
         "type='signal',interface='org.freedesktop.DBus.Properties'", &error);
@@ -125,7 +177,7 @@ int main(int argc, char* argv[]) {
         if (msg != NULL) {
             if (dbus_message_is_signal(msg, "org.freedesktop.DBus.Properties",
                     "PropertiesChanged")) {
-                handle_orientation(parse_orientation(msg));
+                handle_orientation(parse_orientation_signal(msg));
             } else {
                 dbus_message_unref(msg);
                 break;
@@ -133,6 +185,25 @@ int main(int argc, char* argv[]) {
             dbus_message_unref(msg);
         }
     }
+}
+
+int main(int argc, char* argv[]) {
+    DBusConnection* connection = dbus_connect();
+    if (connection == NULL) {
+        printf("error: cannot open dbus connection\n");
+        return 1;
+    }
+    if (argc > 1) {
+        output = argv[1];
+    }
+
+    // if sway and iio-sway are restarted after display is already rotated,
+    // init_orientation ensures correct immediate orientation without
+    // waiting for display to move
+    init_orientation(connection);
+
+    listen_orientation(connection);
+
     dbus_disconnect(connection);
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -66,7 +66,7 @@ enum Orientation parse_orientation_signal(DBusMessage* msg) {
                 dbus_message_iter_next(&iter_dict);
                 dbus_message_iter_recurse(&iter_dict, &iter_v);
                 dbus_message_iter_get_basic(&iter_v, &orientation);
-    		return property_to_enum(orientation);
+                return property_to_enum(orientation);
             }
         }
     }
@@ -135,7 +135,7 @@ DBusMessage* request_orientation(DBusConnection* conn) {
     // check reply
     if (dbus_error_is_set(&error)) {
         printf("Error receiving orientation request: %s: %s\n",
-	       error.name, error.message);
+               error.name, error.message);
     }
 
     // clean up and return


### PR DESCRIPTION
e.g. when logging in/out with gtkgreet.

I keep my display in "portrait mode", and use greetd+gtkgreet to log in. I have gtkgreet running with its own sway config (plus iio-sway for correct orientation) which is killed upon login and replaced with my main sway config. However, upon login, the orientation was incorrect and I had to physically rotate the display to "landscape mode" and back again to force orientation detection. It was the same on logout back to gtkgreet. This fixes that. iio-sway now proactively sets orientation at start, even if no change is detected, before going to passive listening mode. My current set-up has iio-sway started for gtkgreet (with sway), killed/restarted at login (with sway), and killed/restarted again at logout back to gtkgreet (with sway).