### PR TITLE
Add Nix flake and Home Manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,36 @@
 # iio-sway
+
 Listen iio-sensor-proxy and auto change sway output orientation
 
-## installing 
+## installing
+
 1. Make sure iio-sensor-proxy running
 2. add exec iio-sway to your sway config file
 
 ## running
-./iio-sway [sway-output to rotate, default=eDP-1], run **swaymsg -t get_outputs** to list.
+
+./iio-sway [sway-output to rotate, default=eDP-1], run **swaymsg -t
+get_outputs** to list.
+
+## NixOS with Home Manager
+
+In your flake.nix
+
+```nix
+inputs.iio-sway.url = "github:tbaumann/iio-sway";
+```
+
+Use it in a home manager module
+
+```nix
+{ config, pkgs, ... }:
+
+{
+  imports = [ inputs.iio-sway.homeManagerModules.default ];
+
+  programs.iio-sway = {
+    enable = true;
+    display = "HDMI-1"; # Optional
+  };
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1739314552,
+        "narHash": "sha256-ggVf2BclyIW3jexc/uvgsgJH4e2cuG6Nyg54NeXgbFI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "83bd3a26ac0526ae04fa74df46738bb44b89dcdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1739367196,
+        "narHash": "sha256-IHKnbfYhJ0RZzdrHG8bE9ojx5C7m6i1z1xHSvdOO7aA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e3a6f79021094151a1a8fe195e380307019b2cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "A Meson-based project built with Nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    home-manager.url = "github:nix-community/home-manager";
+  };
+
+  outputs = inputs @ {self, ...}:
+    with inputs; let
+      inherit (home-manager.lib) homeManagerModules;
+    in
+      flake-utils.lib.eachDefaultSystem (
+        system: let
+          pkgs = import nixpkgs {inherit system;};
+        in {
+          packages.default = pkgs.stdenv.mkDerivation {
+            pname = "iio-sway";
+            version = "1.0";
+
+            src = ./.; # Local source directory
+
+            nativeBuildInputs = with pkgs; [meson ninja pkg-config];
+            buildInputs = with pkgs; [dbus];
+          };
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [meson ninja pkg-config dbus];
+          };
+        }
+      )
+      // {
+        homeManagerModules.default = {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+          with lib; {
+            options.programs.iio-sway = {
+              enable = mkEnableOption "Enable iio-sway in Sway";
+              display = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "Optional display parameter for iio-sway.";
+              };
+            };
+
+            config = mkIf config.programs.iio-sway.enable {
+              wayland.windowManager.sway.config.startup = [
+                {
+                  command =
+                    "${self.packages.${pkgs.system}.default}/bin/iio-sway"
+                    + optionalString (config.programs.iio-sway.display != null) " ${config.programs.iio-sway.display}";
+                }
+              ];
+            };
+          };
+      };
+}


### PR DESCRIPTION
Useful for NixOS users.

I might in the future try to get it into upstream nixpkgs and home-manager, but it's probably not worth it.

Try the build with `nix build` or `nix run`

// The url in the README needs to be rewritten if you decide to merge.